### PR TITLE
Symlink to output files to tail -F easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Or install it yourself as:
 | Name                     | Description                  | Default           |
 |--------------------------|------------------------------|-------------------|
 | LOG_LEVEL                | log level                    | 1 (Logger::INFO)  |
+| EXEC_COMMAND_OUTPUT_ROOT | The command output root      | logs/exec_command |
+| EXEC_COMMAND_OUTPUT_DIR  | The command output directory | "#{root}/%Y-%m    |
 
 ## History
 


### PR DESCRIPTION
To inveticate how `ruboty-exec_command`, I wanted to `tail -F` the output log file, but it was very difficult because the log file name is always changed with `this_time` extension.

I created a patch to create a symlink to a file without `this_time` extension everytime. 

I also defined following enviroment variables:

* EXEC_COMMAND_OUTPUT_ROOT
* EXEC_COMMAND_OUTPUT_DIR

for changing the output log directories to `/tmp` so that logs will be automatically removed by `tmpwatch`. 

PS. Sorry for committing two things in one PR, but I wanted to change `log_dir` name to `output_dir` in along with writing `symlink` path. 