### PR TITLE
Bundler.with_clean_env

### DIFF
--- a/lib/ruboty/exec_command/command.rb
+++ b/lib/ruboty/exec_command/command.rb
@@ -118,14 +118,25 @@ module Ruboty
       def run_bg(args=[])
         stdout, stderr = output_files
         @start_at = this_time
-        @pid = Process.spawn(%Q(#{absolute_path} #{args.join(" ")}),
-                        pgroup: true, out: stdout, err: stderr)
+        with_clean_env do
+          @pid = Process.spawn(%Q(#{absolute_path} #{args.join(" ")}),
+                               pgroup: true, out: stdout, err: stderr)
+        end
       end
 
       def help
         run(args=['-h']).chomp
       end
 
+      def with_clean_env(&block)
+        if defined?(Bundler)
+          Bundler.with_clean_env do
+            yield
+          end
+        else
+          yield
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
To run a ruby script (with bundler) inside ruboty (with bundler), we need to use `Bundler.with_clean_env`. Otherwise, Bundler does not set environment variables such as BUNDLE_GEMFILE because such enviroment variables already exists, and hence, we can not load Gemfile located on a directory to run the ruby script. 