### PR TITLE
Fix not to match with shorter name commands

### DIFF
--- a/lib/ruboty/handlers/command.rb
+++ b/lib/ruboty/handlers/command.rb
@@ -18,7 +18,7 @@ module Ruboty
       # The command should return a usage with -h option
       def self.register_commands
         Ruboty::ExecCommand::Command.all.each do |e|
-          on /#{e.command_name}/i, name: "command_handler", description: e.help
+          on /#{e.command_name}(?:\z|\s+)/i, name: "command_handler", description: e.help
         end
       end
 


### PR DESCRIPTION
When I put scripts like

```
commands/dir/script
commands/dir/script2
```

and let ruboty execute as

```
@ruboty dir script2
```

the `script2` was executed twice. 

It was because `/dir script/i` matches with `"dir script2"` too, in addition to `/dir script2/i`. \

This patch fixes the issue. 