### PR TITLE
Refer to global bundler

### DIFF
--- a/lib/ruboty/exec_command/command.rb
+++ b/lib/ruboty/exec_command/command.rb
@@ -146,8 +146,8 @@ module Ruboty
       end
 
       def with_clean_env(&block)
-        if defined?(Bundler)
-          Bundler.with_clean_env do
+        if defined?(::Bundler)
+          ::Bundler.with_clean_env do
             yield
           end
         else


### PR DESCRIPTION
``` rb
def with_clean_env(&block)
  if defined?(Bundler)
    Bundler.with_clean_env do
      yield
    end
  else
    yield
  end
end
```

from https://github.com/norobust/ruboty-exec_command/blob/master/lib/ruboty/exec_command/command.rb#L148

if you use the gem [ruboty-bundler](https://github.com/r7kamura/ruboty-bundler), 'Bundler' refer to Ruboty::Bundler and raise an error like below:

``` rb
/vendor/bundle/ruby/2.3.0/gems/ruboty-exec_command-0.1.3/lib/ruboty/exec_command/command.rb:150:in `with_clean_env': undefined method `with_clean_env' for Ruboty::Bundler:Module (NoMethodError)
```

I fix to refer to global Bundler.
